### PR TITLE
Add session-based export notifications and queue helper

### DIFF
--- a/app/Exports/AbsenteeismOvertimeReportExport.php
+++ b/app/Exports/AbsenteeismOvertimeReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -13,7 +14,7 @@ use Maatwebsite\Excel\Concerns\ShouldAutoSize;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Events\AfterSheet;
 
-class AbsenteeismOvertimeReportExport implements FromView, ShouldAutoSize, WithEvents
+class AbsenteeismOvertimeReportExport implements FromView, ShouldAutoSize, WithEvents, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $absentDateFrom, $absentDateTo, $groupAuthorizeFrom, $groupAuthorizeTo, $reportType, $includeResign, $position, $ranking, $location, $dataLevel)
     {

--- a/app/Exports/AuditTrailExport.php
+++ b/app/Exports/AuditTrailExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class AuditTrailExport implements FromView, ShouldAutoSize
+class AuditTrailExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($userID, $userName, $dateFrom, $dateTo, $url)
     {

--- a/app/Exports/BonusTHRReportExport.php
+++ b/app/Exports/BonusTHRReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class BonusTHRReportExport implements FromView, ShouldAutoSize
+class BonusTHRReportExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($report, $paymentDateFrom, $paymentDateTo, $employeeNoFrom, $employeeNoTo, $groupAuthorizedCodeFrom, $groupAuthorizedCodeTo)
     {

--- a/app/Exports/CSVESPTReportFormExport.php
+++ b/app/Exports/CSVESPTReportFormExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class CSVESPTReportFormExport implements FromView, ShouldAutoSize
+class CSVESPTReportFormExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($format, $periodMonth, $periodYear, $rectification, $npwpGroup, $printDate, $groupAuthorizedCodeFrom, $groupAuthorizedCodeTo)
     {

--- a/app/Exports/CustomReportEmployeeExport.php
+++ b/app/Exports/CustomReportEmployeeExport.php
@@ -10,7 +10,7 @@ use Validator;
 use Session;
 use App;
 
-class CustomReportEmployeeExport implements FromView, ShouldAutoSize
+class CustomReportEmployeeExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $employmentStatus, $includeResign, $groupAuthorizeFrom, $groupAuthorizeTo, $dataField)
     {

--- a/app/Exports/DUMTKReportExport.php
+++ b/app/Exports/DUMTKReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class DUMTKReportExport implements FromView, ShouldAutoSize
+class DUMTKReportExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($asOfPeriod, $employeeNoFrom, $employeeNoTo, $groupAuthorizedCodeFrom, $groupAuthorizedCodeTo, $BPJSGroupFrom, $BPJSGroupTo)
     {

--- a/app/Exports/DetailAbsenteeismReasonReportExport.php
+++ b/app/Exports/DetailAbsenteeismReasonReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class DetailAbsenteeismReasonReportExport implements FromView, ShouldAutoSize
+class DetailAbsenteeismReasonReportExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $absentDateFrom, $absentDateTo, $groupAuthorizeFrom, $groupAuthorizeTo, $includeResign, $position, $ranking, $location, $dataLevel, $dataField)
     {

--- a/app/Exports/DetailAbsenteeismReportExport.php
+++ b/app/Exports/DetailAbsenteeismReportExport.php
@@ -13,7 +13,7 @@ use Validator;
 use Session;
 use App;
 
-class DetailAbsenteeismReportExport implements FromView, ShouldAutoSize
+class DetailAbsenteeismReportExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $absentDateFrom, $absentDateTo, $groupAuthorizeFrom, $groupAuthorizeTo, $includeResign, $position, $ranking, $location, $dataLevel, $dataField)
     {

--- a/app/Exports/DetailRateOvertimeReportExport.php
+++ b/app/Exports/DetailRateOvertimeReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class DetailRateOvertimeReportExport implements FromView, ShouldAutoSize
+class DetailRateOvertimeReportExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $absentDateFrom, $absentDateTo, $groupAuthorizeFrom, $groupAuthorizeTo, $includeResign, $position, $ranking, $location, $dataLevel, $dataField)
     {

--- a/app/Exports/EmployeeCardExport.php
+++ b/app/Exports/EmployeeCardExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class EmployeeCardExport implements FromView, ShouldAutoSize
+class EmployeeCardExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     // public function __construct($employeeNoFrom, $employeeNoTo, $includeResign, $position, $ranking, $location, $family, $training_records, $formal_education, $historical_jobs, $language, $work_experience, $organization, $award, $project_experience, $sanction)
     // {

--- a/app/Exports/EmployeeDependentsExport.php
+++ b/app/Exports/EmployeeDependentsExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class EmployeeDependentsExport implements FromView, ShouldAutoSize
+class EmployeeDependentsExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $period, $includeResign, $includeMedical, $includePayroll, $groupAuthorizeFrom, $groupAuthorizeTo, $position, $ranking, $location, $dataLevel)
     {

--- a/app/Exports/EmployeeEvaluationReportExport.php
+++ b/app/Exports/EmployeeEvaluationReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class EmployeeEvaluationReportExport implements FromView, ShouldAutoSize
+class EmployeeEvaluationReportExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $period, $includeResign, $groupAuthorizeFrom, $groupAuthorizeTo, $position, $ranking, $location, $dataLevel)
     {

--- a/app/Exports/EmployeeListExport.php
+++ b/app/Exports/EmployeeListExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class EmployeeListExport implements FromView, ShouldAutoSize
+class EmployeeListExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $period, $includeResign, $inputType, $groupAuthorizeFrom, $groupAuthorizeTo, $position, $ranking, $location, $dataLevel)
     {

--- a/app/Exports/EmployeeReportByStatusExport.php
+++ b/app/Exports/EmployeeReportByStatusExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class EmployeeReportByStatusExport implements FromView, ShouldAutoSize
+class EmployeeReportByStatusExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     /**
     * @return \Illuminate\Support\Collection

--- a/app/Exports/EmployeeSkillReportExport.php
+++ b/app/Exports/EmployeeSkillReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class EmployeeSkillReportExport implements FromView, ShouldAutoSize
+class EmployeeSkillReportExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $period, $includeResign, $groupAuthorizeFrom, $groupAuthorizeTo, $position, $ranking, $location, $dataLevel)
     {

--- a/app/Exports/EmployeeTurnOverReportExport.php
+++ b/app/Exports/EmployeeTurnOverReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class EmployeeTurnOverReportExport implements FromView, ShouldAutoSize
+class EmployeeTurnOverReportExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $periodFrom, $periodTo, $groupAuthorizeFrom, $groupAuthorizeTo, $position, $ranking, $location, $dataLevel)
     {

--- a/app/Exports/JournalReportExcel.php
+++ b/app/Exports/JournalReportExcel.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,8 @@ use Validator;
 use Session;
 use App;
 
-class JournalReportExcel implements FromView, ShouldAutoSize{
+class JournalReportExcel implements FromView, ShouldAutoSize, ShouldQueue
+{
     public function __construct($journalPeriod, $groupAuthorizeFrom, $groupAuthorizeTo){
         $this->journalPeriod = $journalPeriod;
         $this->groupAuthorizeFrom = $groupAuthorizeFrom;

--- a/app/Exports/MonthlyAbsenteeismAnalysisExport.php
+++ b/app/Exports/MonthlyAbsenteeismAnalysisExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class MonthlyAbsenteeismAnalysisExport implements FromView, ShouldAutoSize
+class MonthlyAbsenteeismAnalysisExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $period, $includeResign, $groupAuthorizeFrom, $groupAuthorizeTo, $position, $ranking, $location, $dataLevel)
     {

--- a/app/Exports/MonthlyAbsenteeismDetailExport.php
+++ b/app/Exports/MonthlyAbsenteeismDetailExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class MonthlyAbsenteeismDetailExport implements FromView, ShouldAutoSize
+class MonthlyAbsenteeismDetailExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $absentMonthFrom, $absentMonthTo, $includeResign, $changeHeader, $dataDetail, $hourOut, $hourTo, $groupAuthorizeFrom, $groupAuthorizeTo, $position, $ranking, $location, $dataLevel)
     {

--- a/app/Exports/MonthlyLeaveReportExport.php
+++ b/app/Exports/MonthlyLeaveReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class MonthlyLeaveReportExport implements FromView, ShouldAutoSize
+class MonthlyLeaveReportExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $period, $haveBalanceOnly, $includeResign, $groupAuthorizeFrom, $groupAuthorizeTo, $position, $ranking, $location, $dataLevel)
     {

--- a/app/Exports/PersonalDataExport.php
+++ b/app/Exports/PersonalDataExport.php
@@ -7,11 +7,12 @@ use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Validator;
 use Session;
 use App;
 
-class PersonalDataExport implements FromView, ShouldAutoSize
+class PersonalDataExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function view(): View
     {

--- a/app/Exports/PersonalDataTemplateExport.php
+++ b/app/Exports/PersonalDataTemplateExport.php
@@ -2,9 +2,10 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 
-class PersonalDataTemplateExport implements WithMultipleSheets
+class PersonalDataTemplateExport implements WithMultipleSheets, ShouldQueue
 {
     public function sheets(): array
     {

--- a/app/Exports/PostponeLeaveReportExport.php
+++ b/app/Exports/PostponeLeaveReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class PostponeLeaveReportExport implements FromView, ShouldAutoSize 
+class PostponeLeaveReportExport implements FromView, ShouldAutoSize , ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $period, $includeResign, $groupAuthorizeFrom, $groupAuthorizeTo, $position, $ranking, $location, $dataLevel)
     {

--- a/app/Exports/SalaryHistoricalReportExport.php
+++ b/app/Exports/SalaryHistoricalReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class SalaryHistoricalReportExport implements FromView, ShouldAutoSize
+class SalaryHistoricalReportExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $groupAuthorizedCodeFrom, $groupAuthorizedCodeTo)
     {

--- a/app/Exports/SeveranceReportExcel.php
+++ b/app/Exports/SeveranceReportExcel.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class SeveranceReportExcel implements FromView, ShouldAutoSize
+class SeveranceReportExcel implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($paymentDateFrom, $paymentDateTo, $employeeNoFrom, $employeeNoTo, $groupAuthorizedFrom, $groupAuthorizedTo)
     {

--- a/app/Exports/TemplatePayrollDataTemplateSheet.php
+++ b/app/Exports/TemplatePayrollDataTemplateSheet.php
@@ -2,12 +2,13 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use Maatwebsite\Excel\Concerns\WithTitle;
 use Maatwebsite\Excel\Concerns\ShouldAutoSize;
 
-class TemplatePayrollDataTemplateSheet implements FromView, WithTitle, ShouldAutoSize
+class TemplatePayrollDataTemplateSheet implements FromView, WithTitle, ShouldAutoSize, ShouldQueue
 {
     public function __construct($columnA, $columnB, $columnC, $columnD, $columnE, $columnF, $columnG, $columnH, $columnI, $columnJ, $columnK, $columnL)
     {

--- a/app/Exports/TemplatePersonalDataInfoSheet.php
+++ b/app/Exports/TemplatePersonalDataInfoSheet.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use Maatwebsite\Excel\Concerns\WithTitle;
@@ -12,7 +13,7 @@ use Validator;
 use Session;
 use App;
 
-class TemplatePersonalDataInfoSheet implements FromView, WithTitle, ShouldAutoSize
+class TemplatePersonalDataInfoSheet implements FromView, WithTitle, ShouldAutoSize, ShouldQueue
 {
     public function view(): View
     {

--- a/app/Exports/TemplatePersonalDataTemplateSheet.php
+++ b/app/Exports/TemplatePersonalDataTemplateSheet.php
@@ -2,12 +2,13 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use Maatwebsite\Excel\Concerns\WithTitle;
 use Maatwebsite\Excel\Concerns\ShouldAutoSize;
 
-class TemplatePersonalDataTemplateSheet implements FromView, WithTitle, ShouldAutoSize
+class TemplatePersonalDataTemplateSheet implements FromView, WithTitle, ShouldAutoSize, ShouldQueue
 {
     public function view(): View
     {

--- a/app/Exports/UnpaidLeaveReportExport.php
+++ b/app/Exports/UnpaidLeaveReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use Maatwebsite\Excel\Concerns\ShouldQueue;
 use Maatwebsite\Excel\Concerns\FromView;
 use Illuminate\Contracts\View\View;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use Validator;
 use Session;
 use App;
 
-class UnpaidLeaveReportExport implements FromView, ShouldAutoSize
+class UnpaidLeaveReportExport implements FromView, ShouldAutoSize, ShouldQueue
 {
     public function __construct($employeeNoFrom, $employeeNoTo, $period, $includeResign, $groupAuthorizeFrom, $groupAuthorizeTo, $position, $ranking, $location, $dataLevel)
     {

--- a/app/Http/Controllers/ExportNotificationController.php
+++ b/app/Http/Controllers/ExportNotificationController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\Storage;
+
+class ExportNotificationController extends Controller
+{
+    public function index()
+    {
+        return response()->json(Session::get('export_jobs', []));
+    }
+
+    public function download($id)
+    {
+        $jobs = Session::get('export_jobs', []);
+        foreach ($jobs as $key => $job) {
+            if ($job['id'] === $id && Storage::exists($job['path'])) {
+                $file = Storage::path($job['path']);
+                $name = basename($file);
+                Storage::delete($job['path']);
+                unset($jobs[$key]);
+                Session::put('export_jobs', $jobs);
+                return response()->download($file, $name);
+            }
+        }
+        abort(404);
+    }
+
+    public function destroy($id)
+    {
+        $jobs = Session::get('export_jobs', []);
+        foreach ($jobs as $key => $job) {
+            if ($job['id'] === $id) {
+                if (Storage::exists($job['path'])) {
+                    Storage::delete($job['path']);
+                }
+                unset($jobs[$key]);
+                break;
+            }
+        }
+        Session::put('export_jobs', $jobs);
+        return response()->json(['status' => 'removed']);
+    }
+}

--- a/app/Http/Controllers/PayrollController.php
+++ b/app/Http/Controllers/PayrollController.php
@@ -24,9 +24,11 @@ use DataTables;
 use Excel;
 use PDF;
 use PhpParser\Node\NullableType;
+use App\Traits\QueuesExport;
 
 class PayrollController extends Controller
 {
+    use QueuesExport;
     public function pagePayroll() 
     {
         return view ('payroll.py_main');
@@ -4903,12 +4905,12 @@ public function dataDetailReportFormatPY(Request $request)
 
     public function templateImportDataFromExcelPY(Request $request)
     {
-        return Excel::download(new TemplatePayrollDataTemplateSheet(
-            $request->column_a, 
-            $request->column_b, 
-            $request->column_c, 
-            $request->column_d, 
-            $request->column_e, 
+        $this->queueExport(new TemplatePayrollDataTemplateSheet(
+            $request->column_a,
+            $request->column_b,
+            $request->column_c,
+            $request->column_d,
+            $request->column_e,
             $request->column_f,
             $request->column_g,
             $request->column_h,
@@ -4917,6 +4919,7 @@ public function dataDetailReportFormatPY(Request $request)
             $request->column_k,
             $request->column_l
         ), 'Template Payroll Data.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function prosesSptFormatPY(Request $request)
@@ -5788,7 +5791,15 @@ public function dataDetailReportFormatPY(Request $request)
     }
 
     public function printSeveranceReportPayrollExcel(Request $request){
-        return Excel::download(new SeveranceReportExcel($request->payment_date_from, $request->payment_date_to, $request->employee_no_from, $request->employee_no_to, intval($request->group_authorized_from), intval($request->group_authorized_to)), 'Severance Report.xlsx');
+        $this->queueExport(new SeveranceReportExcel(
+            $request->payment_date_from,
+            $request->payment_date_to,
+            $request->employee_no_from,
+            $request->employee_no_to,
+            intval($request->group_authorized_from),
+            intval($request->group_authorized_to)
+        ), 'Severance Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printJournalReportPayroll(Request $request){
@@ -5840,7 +5851,12 @@ public function dataDetailReportFormatPY(Request $request)
 
     public function printJournalReportPayrollExcel(Request $request){
         // var_dump($request->journal_period, $request->group_authorized_from, $request->group_authorized_to);
-        return Excel::download(new JournalReportExcel($request->journal_period, $request->group_authorized_from, $request->group_authorized_to), 'Journal Report.xlsx');
+        $this->queueExport(new JournalReportExcel(
+            $request->journal_period,
+            $request->group_authorized_from,
+            $request->group_authorized_to
+        ), 'Journal Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printPaymentSlipPayroll(Request $request){
@@ -6039,16 +6055,16 @@ public function dataDetailReportFormatPY(Request $request)
     }
 
     public function printDUMTKPayrollExcel(Request $request){
-        return Excel::download(new DUMTKReportExport(
+        $this->queueExport(new DUMTKReportExport(
             $request->as_of_period,
-            $request->employee_no_from, 
+            $request->employee_no_from,
             $request->employee_no_to,
             $request->group_authorized_code_from,
             $request->group_authorized_code_to,
             $request->bpjs_group_from,
-            $request->bpjs_group_to), 
-            'DUMTK Report Form.xlsx'
-        );
+            $request->bpjs_group_to
+        ), 'DUMTK Report Form.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printSalaryHistoricalReportPayroll(Request $request){
@@ -6110,27 +6126,27 @@ public function dataDetailReportFormatPY(Request $request)
     }
 
     public function printSalaryHistoricalReportPayrollExcel(Request $request){
-        return Excel::download(new SalaryHistoricalReportExport(
-            $request->employee_no_from, 
+        $this->queueExport(new SalaryHistoricalReportExport(
+            $request->employee_no_from,
             $request->employee_no_to,
             $request->group_authorized_code_from,
-            $request->group_authorized_code_to), 
-            'Salary Historical Report.xlsx'
-        );
+            $request->group_authorized_code_to
+        ), 'Salary Historical Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printCSVESPTReportFormPayrollExcel(Request $request){
-        return Excel::download(new CSVESPTReportFormExport(
-            $request->format, 
+        $this->queueExport(new CSVESPTReportFormExport(
+            $request->format,
             $request->period_month,
             $request->period_year,
             $request->rectification,
             $request->npwp_group,
             $request->print_date,
             $request->group_authorized_code_from,
-            $request->group_authorized_code_to), 
-            'CSVEsptMasa.xlsx'
-        );
+            $request->group_authorized_code_to
+        ), 'CSVEsptMasa.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printBonusTHRReportPayroll(Request $request){
@@ -6211,16 +6227,16 @@ public function dataDetailReportFormatPY(Request $request)
     }
 
     public function printBonusTHRReportPayrollExcel(Request $request){
-        return Excel::download(new BonusTHRReportExport(
-            $request->report, 
+        $this->queueExport(new BonusTHRReportExport(
+            $request->report,
             $request->payment_date_from,
             $request->payment_date_to,
             $request->employee_no_from,
             $request->employee_no_to,
             $request->group_authorized_code_from,
-            $request->group_authorized_code_to), 
-            'Bonus & THR Report.xlsx'
-        );
+            $request->group_authorized_code_to
+        ), 'Bonus & THR Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
 }

--- a/app/Http/Controllers/PersonelController.php
+++ b/app/Http/Controllers/PersonelController.php
@@ -24,9 +24,11 @@ use DataTables;
 use Excel;
 use PDF;
 use PhpParser\Node\NullableType;
+use App\Traits\QueuesExport;
 
 class PersonelController extends Controller
 {
+    use QueuesExport;
     public function pagePersonelMain()
     {
     	return view('personel.personel_main');
@@ -9762,7 +9764,20 @@ class PersonelController extends Controller
 
         // var_dump($request->input_type);
 
-        return Excel::download(new EmployeeListExport($request->employee_no_from, $request->employee_no_to, $request->period, isset($request->include_resign) ? (bool) $request->include_resign : false, $request->input_type, $request->group_authorize_from, $request->group_authorize_to, $request->position, $request->ranking, $request->location, $dataLevel), 'Employee List Report.xlsx');
+        $this->queueExport(new EmployeeListExport(
+            $request->employee_no_from,
+            $request->employee_no_to,
+            $request->period,
+            isset($request->include_resign) ? (bool) $request->include_resign : false,
+            $request->input_type,
+            $request->group_authorize_from,
+            $request->group_authorize_to,
+            $request->position,
+            $request->ranking,
+            $request->location,
+            $dataLevel
+        ), 'Employee List Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printEmployeeTurnOverReportPersonel(Request $request)
@@ -9775,7 +9790,19 @@ class PersonelController extends Controller
 
         // var_dump($request->period);
 
-        return Excel::download(new EmployeeTurnOverReportExport($request->employee_no_from, $request->employee_no_to, $request->period_from, $request->period_to, $request->group_authorize_from, $request->group_authorize_to, $request->position, $request->ranking, $request->location, $dataLevel), 'Employee Turn Over Report.xlsx');
+        $this->queueExport(new EmployeeTurnOverReportExport(
+            $request->employee_no_from,
+            $request->employee_no_to,
+            $request->period_from,
+            $request->period_to,
+            $request->group_authorize_from,
+            $request->group_authorize_to,
+            $request->position,
+            $request->ranking,
+            $request->location,
+            $dataLevel
+        ), 'Employee Turn Over Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printEmployeeSkillReportPersonel(Request $request)
@@ -9788,7 +9815,19 @@ class PersonelController extends Controller
 
         // var_dump($request->period);
 
-        return Excel::download(new EmployeeSkillReportExport($request->employee_no_from, $request->employee_no_to, $request->period, isset($request->include_resign) ? (bool) $request->include_resign : false, $request->group_authorize_from, $request->group_authorize_to, $request->position, $request->ranking, $request->location, $dataLevel), 'Employee Skill Report.xlsx');
+        $this->queueExport(new EmployeeSkillReportExport(
+            $request->employee_no_from,
+            $request->employee_no_to,
+            $request->period,
+            isset($request->include_resign) ? (bool) $request->include_resign : false,
+            $request->group_authorize_from,
+            $request->group_authorize_to,
+            $request->position,
+            $request->ranking,
+            $request->location,
+            $dataLevel
+        ), 'Employee Skill Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printEmployeeCardPersonel(Request $request){
@@ -10000,7 +10039,15 @@ class PersonelController extends Controller
 
     public function printEmployeeReportByStatusPersonel(Request $request)
     {
-        return Excel::download(new EmployeeReportByStatusExport($request->employee_no_from, $request->employee_no_to, $request->period_from, $request->period_to, $request->report_type, isset($request->include_resign) ? (bool) $request->include_resign : false), 'Employee Report By Status.xlsx');
+        $this->queueExport(new EmployeeReportByStatusExport(
+            $request->employee_no_from,
+            $request->employee_no_to,
+            $request->period_from,
+            $request->period_to,
+            $request->report_type,
+            isset($request->include_resign) ? (bool) $request->include_resign : false
+        ), 'Employee Report By Status.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function checkResultPerformancePersonel(Request $request)
@@ -10436,7 +10483,16 @@ class PersonelController extends Controller
 
         $arrData2 = json_decode($request->field_name);
 
-        return Excel::download(new CustomReportEmployeeExport($arrData['employee_no_from'], $arrData['employee_no_to'], $arrData['employment_status'], isset($arrData['include_resign']) ? (bool) $arrData['include_resign'] : false, $arrData['group_authorize_from'], $arrData['group_authorize_to'], $arrData2), 'Custom Report Employee.xlsx');
+        $this->queueExport(new CustomReportEmployeeExport(
+            $arrData['employee_no_from'],
+            $arrData['employee_no_to'],
+            $arrData['employment_status'],
+            isset($arrData['include_resign']) ? (bool) $arrData['include_resign'] : false,
+            $arrData['group_authorize_from'],
+            $arrData['group_authorize_to'],
+            $arrData2
+        ), 'Custom Report Employee.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printEmployeeDependentsPersonel(Request $request)
@@ -10447,17 +10503,33 @@ class PersonelController extends Controller
             $dataLevel[] = $request->{'level' . ($i+1)};
         }
 
-        return Excel::download(new EmployeeDependentsExport($request->employee_no_from, $request->employee_no_to, $request->period, isset($request->include_resign) ? (bool) $request->include_resign : false, isset($request->include_medical) ? (bool) $request->include_medical : false, isset($request->include_payroll) ? (bool) $request->include_payroll : false, $request->group_authorize_from, $request->group_authorize_to, $request->position, $request->ranking, $request->location, $dataLevel), 'Employee Dependents Report.xlsx');
+        $this->queueExport(new EmployeeDependentsExport(
+            $request->employee_no_from,
+            $request->employee_no_to,
+            $request->period,
+            isset($request->include_resign) ? (bool) $request->include_resign : false,
+            isset($request->include_medical) ? (bool) $request->include_medical : false,
+            isset($request->include_payroll) ? (bool) $request->include_payroll : false,
+            $request->group_authorize_from,
+            $request->group_authorize_to,
+            $request->position,
+            $request->ranking,
+            $request->location,
+            $dataLevel
+        ), 'Employee Dependents Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function templatePersonalDataPersonel()
     {
-        return Excel::download(new PersonalDataTemplateExport, 'Template Personel Data.xlsx');
+        $this->queueExport(new PersonalDataTemplateExport, 'Template Personel Data.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function exportPersonalDataPersonel(Request $request)
     {
-        return Excel::download(new PersonalDataExport, 'Personel Data.xlsx');
+        $this->queueExport(new PersonalDataExport, 'Personel Data.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function importPersonalDataPersonel(Request $request)

--- a/app/Http/Controllers/TimeManagementController.php
+++ b/app/Http/Controllers/TimeManagementController.php
@@ -24,9 +24,11 @@ use App;
 use File;
 use DataTables;
 use Excel;
+use App\Traits\QueuesExport;
 
 class TimeManagementController extends Controller
 {
+    use QueuesExport;
     public function pageTimeManagement() 
     {
         return view ('time_management.tm_main');
@@ -1097,7 +1099,19 @@ class TimeManagementController extends Controller
             $dataLevel[] = $request->{'level' . ($i+1)};
         }
 
-        return Excel::download(new UnpaidLeaveReportExport($request->employee_no_from, $request->employee_no_to, $request->period, isset($request->include_resign) ? (bool) $request->include_resign : false, $request->group_authorize_from, $request->group_authorize_to, $request->position, $request->ranking, $request->location, $dataLevel), 'Unpaid Leave Report.xlsx');
+        $this->queueExport(new UnpaidLeaveReportExport(
+            $request->employee_no_from,
+            $request->employee_no_to,
+            $request->period,
+            isset($request->include_resign) ? (bool) $request->include_resign : false,
+            $request->group_authorize_from,
+            $request->group_authorize_to,
+            $request->position,
+            $request->ranking,
+            $request->location,
+            $dataLevel
+        ), 'Unpaid Leave Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printPostponeLeaveReport(Request $request)
@@ -1108,7 +1122,19 @@ class TimeManagementController extends Controller
             $dataLevel[] = $request->{'level' . ($i+1)};
         }
 
-        return Excel::download(new PostponeLeaveReportExport($request->employee_no_from, $request->employee_no_to, $request->period, isset($request->include_resign) ? (bool) $request->include_resign : false, $request->group_authorize_from, $request->group_authorize_to, $request->position, $request->ranking, $request->location, $dataLevel), 'Postpone Leave Report.xlsx');
+        $this->queueExport(new PostponeLeaveReportExport(
+            $request->employee_no_from,
+            $request->employee_no_to,
+            $request->period,
+            isset($request->include_resign) ? (bool) $request->include_resign : false,
+            $request->group_authorize_from,
+            $request->group_authorize_to,
+            $request->position,
+            $request->ranking,
+            $request->location,
+            $dataLevel
+        ), 'Postpone Leave Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
     
     public function printMonthlyLeaveReport(Request $request)
@@ -1119,7 +1145,20 @@ class TimeManagementController extends Controller
             $dataLevel[] = $request->{'level' . ($i+1)};
         }
 
-        return Excel::download(new MonthlyLeaveReportExport($request->employee_no_from, $request->employee_no_to, $request->period, isset($request->have_balance_only) ? (bool) $request->have_balance_only : false, isset($request->include_resign) ? (bool) $request->include_resign : false, $request->group_authorize_from, $request->group_authorize_to, $request->position, $request->ranking, $request->location, $dataLevel), 'Monthly Leave Report.xlsx');
+        $this->queueExport(new MonthlyLeaveReportExport(
+            $request->employee_no_from,
+            $request->employee_no_to,
+            $request->period,
+            isset($request->have_balance_only) ? (bool) $request->have_balance_only : false,
+            isset($request->include_resign) ? (bool) $request->include_resign : false,
+            $request->group_authorize_from,
+            $request->group_authorize_to,
+            $request->position,
+            $request->ranking,
+            $request->location,
+            $dataLevel
+        ), 'Monthly Leave Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printMonthlyAbsenteeismAnalysis(Request $request)
@@ -1130,7 +1169,19 @@ class TimeManagementController extends Controller
             $dataLevel[] = $request->{'level' . ($i+1)};
         }
 
-        return Excel::download(new MonthlyAbsenteeismAnalysisExport($request->employee_no_from, $request->employee_no_to, $request->period, isset($request->include_resign) ? (bool) $request->include_resign : false, $request->group_authorize_from, $request->group_authorize_to, $request->position, $request->ranking, $request->location, $dataLevel), 'Monthly Absenteeism Analysis.xlsx');
+        $this->queueExport(new MonthlyAbsenteeismAnalysisExport(
+            $request->employee_no_from,
+            $request->employee_no_to,
+            $request->period,
+            isset($request->include_resign) ? (bool) $request->include_resign : false,
+            $request->group_authorize_from,
+            $request->group_authorize_to,
+            $request->position,
+            $request->ranking,
+            $request->location,
+            $dataLevel
+        ), 'Monthly Absenteeism Analysis.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printDetailAbsenteeismReport(Request $request)
@@ -1145,7 +1196,21 @@ class TimeManagementController extends Controller
             $dataLevel[] = $arrData['level' . ($i+1)];
         }
 
-        return Excel::download(new DetailAbsenteeismReportExport($arrData['employee_no_from'],$arrData['employee_no_to'], $arrData['absent_date_from'], $arrData['absent_date_to'], $arrData['group_authorize_from'], $arrData['group_authorize_to'], isset($arrData['include_resign']) ? (bool) $arrData['include_resign'] : false, $arrData['position'], $arrData['ranking'], $arrData['location'], $dataLevel, $arrData2), 'Detail Absenteeism Report.xlsx');
+        $this->queueExport(new DetailAbsenteeismReportExport(
+            $arrData['employee_no_from'],
+            $arrData['employee_no_to'],
+            $arrData['absent_date_from'],
+            $arrData['absent_date_to'],
+            $arrData['group_authorize_from'],
+            $arrData['group_authorize_to'],
+            isset($arrData['include_resign']) ? (bool) $arrData['include_resign'] : false,
+            $arrData['position'],
+            $arrData['ranking'],
+            $arrData['location'],
+            $dataLevel,
+            $arrData2
+        ), 'Detail Absenteeism Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printDetailAbsenteeismReasonReport(Request $request)
@@ -1160,7 +1225,21 @@ class TimeManagementController extends Controller
             $dataLevel[] = $arrData['level' . ($i+1)];
         }
 
-        return Excel::download(new DetailAbsenteeismReasonReportExport($arrData['employee_no_from'],$arrData['employee_no_to'], $arrData['absent_date_from'], $arrData['absent_date_to'], $arrData['group_authorize_from'], $arrData['group_authorize_to'], isset($arrData['include_resign']) ? (bool) $arrData['include_resign'] : false, $arrData['position'], $arrData['ranking'], $arrData['location'], $dataLevel, $arrData2), 'Detail Absenteeism Reason Report.xlsx');    
+        $this->queueExport(new DetailAbsenteeismReasonReportExport(
+            $arrData['employee_no_from'],
+            $arrData['employee_no_to'],
+            $arrData['absent_date_from'],
+            $arrData['absent_date_to'],
+            $arrData['group_authorize_from'],
+            $arrData['group_authorize_to'],
+            isset($arrData['include_resign']) ? (bool) $arrData['include_resign'] : false,
+            $arrData['position'],
+            $arrData['ranking'],
+            $arrData['location'],
+            $dataLevel,
+            $arrData2
+        ), 'Detail Absenteeism Reason Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printDetailRateOvertimeReport(Request $request)
@@ -1175,7 +1254,21 @@ class TimeManagementController extends Controller
             $dataLevel[] = $arrData['level' . ($i+1)];
         }
 
-        return Excel::download(new DetailRateOvertimeReportExport($arrData['employee_no_from'],$arrData['employee_no_to'], $arrData['absent_date_from'], $arrData['absent_date_to'], $arrData['group_authorize_from'], $arrData['group_authorize_to'], isset($arrData['include_resign']) ? (bool) $arrData['include_resign'] : false, $arrData['position'], $arrData['ranking'], $arrData['location'], $dataLevel, $arrData2), 'Detail Rate Overtime Report.xlsx');
+        $this->queueExport(new DetailRateOvertimeReportExport(
+            $arrData['employee_no_from'],
+            $arrData['employee_no_to'],
+            $arrData['absent_date_from'],
+            $arrData['absent_date_to'],
+            $arrData['group_authorize_from'],
+            $arrData['group_authorize_to'],
+            isset($arrData['include_resign']) ? (bool) $arrData['include_resign'] : false,
+            $arrData['position'],
+            $arrData['ranking'],
+            $arrData['location'],
+            $dataLevel,
+            $arrData2
+        ), 'Detail Rate Overtime Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printMonthlyAbsenteeismDetail(Request $request)
@@ -1189,7 +1282,24 @@ class TimeManagementController extends Controller
             $dataLevel[] = $arrData['level' . ($i+1)];
         }
 
-        return Excel::download(new MonthlyAbsenteeismDetailExport($arrData['employee_no_from'], $arrData['employee_no_to'], $arrData['absent_month_from'], $arrData['absent_month_to'], isset($arrData['include_resign']) ? (bool) $arrData['include_resign'] : false, isset($arrData['change_header']) ? (bool) $arrData['change_header'] : false, $arrData2, $arrData['hour_out'], $arrData['hour_to'], $arrData['group_authorize_from'], $arrData['group_authorize_to'], $arrData['position'], $arrData['ranking'], $arrData['location'], $dataLevel), 'Monthly Absenteeism Analysis.xlsx');
+        $this->queueExport(new MonthlyAbsenteeismDetailExport(
+            $arrData['employee_no_from'],
+            $arrData['employee_no_to'],
+            $arrData['absent_month_from'],
+            $arrData['absent_month_to'],
+            isset($arrData['include_resign']) ? (bool) $arrData['include_resign'] : false,
+            isset($arrData['change_header']) ? (bool) $arrData['change_header'] : false,
+            $arrData2,
+            $arrData['hour_out'],
+            $arrData['hour_to'],
+            $arrData['group_authorize_from'],
+            $arrData['group_authorize_to'],
+            $arrData['position'],
+            $arrData['ranking'],
+            $arrData['location'],
+            $dataLevel
+        ), 'Monthly Absenteeism Analysis.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function printAbsenteeismOvertimeReport(Request $request)
@@ -1200,7 +1310,21 @@ class TimeManagementController extends Controller
             $dataLevel[] = $request->{'level' . ($i+1)};
         }
 
-        return Excel::download(new AbsenteeismOvertimeReportExport($request->employee_no_from, $request->employee_no_to, $request->absent_date_from, $request->absent_date_to, $request->group_authorize_from, $request->group_authorize_to, $request->report_type, isset($request->include_resign) ? (bool) $request->include_resign : false, $request->position, $request->ranking, $request->location, $dataLevel), 'Absenteeism & Overtime Report.xlsx');
+        $this->queueExport(new AbsenteeismOvertimeReportExport(
+            $request->employee_no_from,
+            $request->employee_no_to,
+            $request->absent_date_from,
+            $request->absent_date_to,
+            $request->group_authorize_from,
+            $request->group_authorize_to,
+            $request->report_type,
+            isset($request->include_resign) ? (bool) $request->include_resign : false,
+            $request->position,
+            $request->ranking,
+            $request->location,
+            $dataLevel
+        ), 'Absenteeism & Overtime Report.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function importUpdateAbsenteeismData(Request $request)

--- a/app/Http/Controllers/UtilitiesController.php
+++ b/app/Http/Controllers/UtilitiesController.php
@@ -12,9 +12,11 @@ use Session;
 use App;
 use DataTables;
 use Excel;
+use App\Traits\QueuesExport;
 
 class UtilitiesController extends Controller
 {
+    use QueuesExport;
     public function pageUtilitiesMain()
     {
     	return view('utilities.utilities_main');
@@ -1322,7 +1324,14 @@ class UtilitiesController extends Controller
 
     public function exportAuditTrailUtilities(Request $request)
     {
-        return Excel::download(new AuditTrailExport($request->user_id, $request->user_name, $request->log_date_from, $request->log_date_to, $request->url_log), 'Audit Trail ' . $request->table . 'Log.xlsx');
+        $this->queueExport(new AuditTrailExport(
+            $request->user_id,
+            $request->user_name,
+            $request->log_date_from,
+            $request->log_date_to,
+            $request->url_log
+        ), 'Audit Trail ' . $request->table . 'Log.xlsx');
+        return response()->json(['status' => 'Export queued']);
     }
 
     public function removeUserAccessGroupUserUtilities(Request $request)

--- a/app/Traits/QueuesExport.php
+++ b/app/Traits/QueuesExport.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Maatwebsite\Excel\Facades\Excel;
+
+trait QueuesExport
+{
+    protected function queueExport($export, string $fileName): string
+    {
+        $company = Session::get('companyCode');
+        $user = Session::get('userID');
+        $path = "exports/$company/$user";
+        Storage::makeDirectory($path);
+        Excel::queue($export, "$path/$fileName");
+        $jobId = (string) Str::uuid();
+        Session::push('export_jobs', [
+            'id' => $jobId,
+            'filename' => $fileName,
+            'path' => "$path/$fileName",
+            'status' => 'queued',
+            'progress' => 0,
+        ]);
+        return $jobId;
+    }
+}

--- a/resources/views/main.blade.php
+++ b/resources/views/main.blade.php
@@ -147,11 +147,18 @@
 				<div class="navbar-collapse company-link" style="display: block !important;">
 					<span>{{ Session::get('companyName') }}</span> 
 				</div>
-				<div class="navbar-collapse right-link">
-					<span class="navbar-divide-complete">|</span>
-					<div class="img-setting-link"><a href="{{ url('/utilities') }}" target="iframe_dashboard"><img src="{{ url('/pictures/setting-white.png') }}" alt="Setting"></a></div>
-					<span class="navbar-divide">|</span>
-					<div class="dropdown-profile">
+                                <div class="navbar-collapse right-link">
+                                        <span class="navbar-divide-complete">|</span>
+                                        <div class="notification-link">
+                                                <a href="#" data-toggle="modal" data-target="#modal_notification">
+                                                        <i class="fa fa-bell"></i>
+                                                        <span class="badge badge-danger">{{ count(Session::get('export_jobs', [])) }}</span>
+                                                </a>
+                                        </div>
+                                        <span class="navbar-divide">|</span>
+                                        <div class="img-setting-link"><a href="{{ url('/utilities') }}" target="iframe_dashboard"><img src="{{ url('/pictures/setting-white.png') }}" alt="Setting"></a></div>
+                                        <span class="navbar-divide">|</span>
+                                        <div class="dropdown-profile">
 						@if(Session::get('photo') == NULL)
 						<img src="{{ url('/pictures/default-profile.png') }}" alt="Profile">
 						@else
@@ -171,7 +178,7 @@
 			<iframe src="{{ url('/home') }}" name="iframe_dashboard" id="iframe_dashboard" class="container-fluid" frameborder="0"></iframe>
 		</div>
 	</div>
-	<div class="modal fade" id="modal_change_language" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal fade" id="modal_change_language" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
             	<div class="modal-header" id="modal-header-change-language">
@@ -205,6 +212,33 @@
                     <button type="button" class="btn btn-danger w-50" data-dismiss="modal"><i class="fa fa-times-circle"></i> Cancel</button>
                 </div>
                 </form>
+            </div>
+        </div>
+    </div>
+    <div class="modal fade" id="modal_notification" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header modal-header-notification">
+                    <h5 class="modal-title">Downloads</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    @foreach(Session::get('export_jobs', []) as $job)
+                        <div class="mb-3">
+                            <p>{{ $job['filename'] }}</p>
+                            @if($job['status'] === 'queued')
+                                <div class="progress">
+                                    <div class="progress-bar" role="progressbar" style="width: {{ $job['progress'] }}%;" aria-valuenow="{{ $job['progress'] }}" aria-valuemin="0" aria-valuemax="100">{{ $job['progress'] }}%</div>
+                                </div>
+                            @else
+                                <a href="{{ url('exports/notifications/'.$job['id'].'/download') }}" class="btn btn-primary btn-sm">Download</a>
+                            @endif
+                            <button class="btn btn-danger btn-sm" onclick="removeExport('{{ $job['id'] }}')"><i class="fa fa-trash"></i></button>
+                        </div>
+                    @endforeach
+                </div>
             </div>
         </div>
     </div>
@@ -278,9 +312,18 @@
 			$('#sidebar-wrapper').toggleClass('active');
 		});
 
-	})(jQuery);
+        })(jQuery);
 
-	$(document).ready(function() {
+        function removeExport(id){
+                $.ajax({
+                        url: '{{ url('exports/notifications') }}/' + id,
+                        type: 'DELETE',
+                        headers: { 'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content') },
+                        success: function(){ location.reload(); }
+                });
+        }
+
+        $(document).ready(function() {
 		$('.list-group-item-action').first().toggleClass('active');
 		$('.list-group-item-action').first().find('.color-active').toggleClass('active');
 

--- a/resources/views/personel/personel_import_export_personal_data.blade.php
+++ b/resources/views/personel/personel_import_export_personal_data.blade.php
@@ -208,36 +208,15 @@
                 }
             });
             $.ajax({
-                xhrFields: {
-                    responseType: 'blob',
-                },
                 url: "{{ url('personel/personal_data/export') }}",
                 type: "POST",
-                success: function (result, status, xhr) {
+                success: function (response) {
                     $("#btn-export").prop("disabled", false);
                     $("#btn-export").html(
                         '{{ __("personel_import_export_personal_data.btn-export") }}'
                     );
-                    
-                    var disposition = xhr.getResponseHeader(
-                        'content-disposition');
-                    var matches = /"([^"]*)"/.exec(disposition);
-                    var filename = (matches != null && matches[1] ? matches[1] :
-                        'audit_trail.xlsx');
-                
-                    // The actual download
-                    var blob = new Blob([result], {
-                        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-                    });
-
-                    var link = document.createElement('a');
-                    link.href = window.URL.createObjectURL(blob);
-                    link.download = filename;
-
-                    document.body.appendChild(link);
-
-                    link.click();
-                    document.body.removeChild(link);
+                    $('#notification').modal('show');
+                    $('#message-notification').html(response.status);
                 },
                 error: function (response) {
                     $("#btn-export").prop("disabled", false);

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,9 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\PersonelController;
+use App\Http\Controllers\UtilitiesController;
+use App\Http\Controllers\ExportNotificationController;
 
 /*
 |--------------------------------------------------------------------------
@@ -367,7 +370,7 @@ Route::post('personel/custom_report_employee/print', 'PersonelController@printCu
 Route::post('personel/evaluation_report/print', 'PersonelController@printEvaluationReportPersonel');
 Route::post('personel/employee_dependents/print', 'PersonelController@printEmployeeDependentsPersonel');
 Route::post('personel/personal_data/template', 'PersonelController@templatePersonalDataPersonel');
-Route::post('personel/personal_data/export', 'PersonelController@exportPersonalDataPersonel');
+Route::post('personel/personal_data/export', [PersonelController::class, 'exportPersonalDataPersonel'])->name('personel.personal_data.export');
 Route::post('personel/personal_data/import', 'PersonelController@importPersonalDataPersonel');
 Route::get('personel/report/level/check', 'PersonelController@checkReportLevelPersonel');
 Route::post('personel/employee/photo/proses', 'PersonelController@prosesEmployeePhotoPersonel');
@@ -765,7 +768,7 @@ Route::post('utilities/user_security_maintenance/level/proses', 'UtilitiesContro
 Route::post('utilities/user_security_maintenance/company/proses', 'UtilitiesController@prosesUserSecurityMaintenanceCompanyUtilities');
 Route::post('utilities/user_security_maintenance/module/proses', 'UtilitiesController@prosesUserSecurityMaintenanceModuleUtilities');
 
-Route::post('utilities/audit_trail/export', 'UtilitiesController@exportAuditTrailUtilities');
+Route::post('utilities/audit_trail/export', [UtilitiesController::class, 'exportAuditTrailUtilities'])->name('utilities.audit_trail.export');
 
 Route::post('utilities/group_user_access/user/add', 'UtilitiesController@addUserAccessGroupUserUtilities');
 Route::get('utilities/group_user_access/user/remove', 'UtilitiesController@removeUserAccessGroupUserUtilities');
@@ -957,3 +960,7 @@ Route::get('disease_code/func/api', 'DataController@dataDiseaseCodeFunctionAPI')
 /* Route Untuk Save Token Device dan Notification Firebase */
 Route::get('save-token', 'DashboardController@saveToken');
 Route::get('send-notification', 'DashboardController@sendNotification');
+
+Route::get('exports/notifications', [ExportNotificationController::class, 'index']);
+Route::get('exports/notifications/{id}/download', [ExportNotificationController::class, 'download']);
+Route::delete('exports/notifications/{id}', [ExportNotificationController::class, 'destroy']);


### PR DESCRIPTION
## Summary
- add reusable `QueuesExport` trait to store queued export jobs in the session
- show pending exports via bell icon and modal with download/remove controls
- expose notification routes for listing, downloading, and clearing export files

## Testing
- `npm test` *(Missing script "test")*
- `composer install --ignore-platform-reqs` *(requires GitHub token for packages)*

------
https://chatgpt.com/codex/tasks/task_e_68abed4f1b6883329b823a9b72452984